### PR TITLE
Swagger Documentation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,11 +11,15 @@ mysqlclient = "~=2.1.1"
 patreon = {ref = "master", git = "https://github.com/Patreon/patreon-python.git"}
 PyYAML = "~=6.0"
 Flask = "~=2.2.3"
+flask-apispec = "~=0.11.0"
+flask-marshmallow = "~=0.14.0"
+flask-swagger-ui = "~=4.11.1"
 Flask-Cors = "~=3.0.10"
 Flask-RESTful = "~=0.3.9"
 Flask-SQLAlchemy = "~=3.0.3"
 uWSGI = "~=2.0.21"
 werkzeug = "~=2.2.3"
+marshmallow-sqlalchemy = "==0.26.1"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "da1fee0ccfecc418c1c253a1c7fc636428d06f16294bda8e9500bd9da3720ed1"
+            "sha256": "cf7535f056b9470f3e4e385df6151411ab8d5728faf0d46929fa1b5bbc65240c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,28 +23,36 @@
             ],
             "version": "==9.0.1"
         },
+        "apispec": {
+            "hashes": [
+                "sha256:6cb08d92ce73ff0b3bf46cb2ea5c00d57289b0f279fb0256a3df468182ba5344",
+                "sha256:95a0b9355785df998bb0e9b939237a30ee4c7428fd6ef97305eae3da06b9b339"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==6.3.0"
+        },
         "blinker": {
             "hashes": [
-                "sha256:5874afe21df4bae8885d31a0a6c4b5861910a575eae6176f051fbb9a6571481b",
-                "sha256:eeebd5dfc782e1817fe4261ce79936c8c8cefb90d685caf50cec458029f773c1"
+                "sha256:4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213",
+                "sha256:c3d739772abb7bc2860abf5f2ec284223d9ad5c76da018234f6f50d6f31ab1f0"
             ],
-            "version": "==1.6"
+            "version": "==1.6.2"
         },
         "cachetools": {
             "hashes": [
-                "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14",
-                "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"
+                "sha256:95ef631eeaea14ba2e36f06437f36463aac3a096799e876ee55e5cdccb102590",
+                "sha256:dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b"
             ],
             "index": "pypi",
-            "version": "==5.3.0"
+            "version": "==5.3.1"
         },
         "certifi": {
             "hashes": [
-                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
-                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
+                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
+                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.12.7"
+            "version": "==2023.5.7"
         },
         "charset-normalizer": {
             "hashes": [
@@ -148,11 +156,19 @@
         },
         "flask": {
             "hashes": [
-                "sha256:7eb373984bf1c770023fce9db164ed0c3353cd0b53f130f4693da0ca756a2e6d",
-                "sha256:c0bec9477df1cb867e5a67c9e1ab758de9cb4a3e52dd70681f59fa40a62b3f2d"
+                "sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf",
+                "sha256:edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0"
             ],
             "index": "pypi",
-            "version": "==2.2.3"
+            "version": "==2.2.5"
+        },
+        "flask-apispec": {
+            "hashes": [
+                "sha256:9a6fedd3a06510a8a19340df676393b336b4ba9d5c159cbb304b62672e3115da",
+                "sha256:dba490a42ffe5e45040a667a5551678099c677eb65b6d5e420cf59ce1dcb6adb"
+            ],
+            "index": "pypi",
+            "version": "==0.11.4"
         },
         "flask-cors": {
             "hashes": [
@@ -162,13 +178,21 @@
             "index": "pypi",
             "version": "==3.0.10"
         },
-        "flask-restful": {
+        "flask-marshmallow": {
             "hashes": [
-                "sha256:4970c49b6488e46c520b325f54833374dc2b98e211f1b272bd4b0c516232afe2",
-                "sha256:ccec650b835d48192138c85329ae03735e6ced58e9b2d9c2146d6c84c06fa53e"
+                "sha256:2adcd782b5a4a6c5ae3c96701f320d8ca6997995a52b2661093c56cc3ed24754",
+                "sha256:bd01a6372cbe50e36f205cfff0fc5dab0b7b662c4c8b2c4fc06a3151b2950950"
             ],
             "index": "pypi",
-            "version": "==0.3.9"
+            "version": "==0.14.0"
+        },
+        "flask-restful": {
+            "hashes": [
+                "sha256:1cf93c535172f112e080b0d4503a8d15f93a48c88bdd36dd87269bdaf405051b",
+                "sha256:fe4af2ef0027df8f9b4f797aba20c5566801b6ade995ac63b588abf1a59cec37"
+            ],
+            "index": "pypi",
+            "version": "==0.3.10"
         },
         "flask-sqlalchemy": {
             "hashes": [
@@ -177,6 +201,14 @@
             ],
             "index": "pypi",
             "version": "==3.0.3"
+        },
+        "flask-swagger-ui": {
+            "hashes": [
+                "sha256:a370199a780d678b32e38f1be10d4d81efa0ee63e9fe2fb766ff1a4b6c37dac8",
+                "sha256:c951928fe4592d3561b543e0e1ca32703f55d3474de86c894a9d27f795d96c83"
+            ],
+            "index": "pypi",
+            "version": "==4.11.1"
         },
         "greenlet": {
             "hashes": [
@@ -270,59 +302,75 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed",
-                "sha256:085fd3201e7b12809f9e6e9bc1e5c96a368c8523fad5afb02afe3c051ae4afcc",
-                "sha256:090376d812fb6ac5f171e5938e82e7f2d7adc2b629101cec0db8b267815c85e2",
-                "sha256:0b462104ba25f1ac006fdab8b6a01ebbfbce9ed37fd37fd4acd70c67c973e460",
-                "sha256:137678c63c977754abe9086a3ec011e8fd985ab90631145dfb9294ad09c102a7",
-                "sha256:1bea30e9bf331f3fef67e0a3877b2288593c98a21ccb2cf29b74c581a4eb3af0",
-                "sha256:22152d00bf4a9c7c83960521fc558f55a1adbc0631fbb00a9471e097b19d72e1",
-                "sha256:22731d79ed2eb25059ae3df1dfc9cb1546691cc41f4e3130fe6bfbc3ecbbecfa",
-                "sha256:2298c859cfc5463f1b64bd55cb3e602528db6fa0f3cfd568d3605c50678f8f03",
-                "sha256:28057e985dace2f478e042eaa15606c7efccb700797660629da387eb289b9323",
-                "sha256:2e7821bffe00aa6bd07a23913b7f4e01328c3d5cc0b40b36c0bd81d362faeb65",
-                "sha256:2ec4f2d48ae59bbb9d1f9d7efb9236ab81429a764dedca114f5fdabbc3788013",
-                "sha256:340bea174e9761308703ae988e982005aedf427de816d1afe98147668cc03036",
-                "sha256:40627dcf047dadb22cd25ea7ecfe9cbf3bbbad0482ee5920b582f3809c97654f",
-                "sha256:40dfd3fefbef579ee058f139733ac336312663c6706d1163b82b3003fb1925c4",
-                "sha256:4cf06cdc1dda95223e9d2d3c58d3b178aa5dacb35ee7e3bbac10e4e1faacb419",
-                "sha256:50c42830a633fa0cf9e7d27664637532791bfc31c731a87b202d2d8ac40c3ea2",
-                "sha256:55f44b440d491028addb3b88f72207d71eeebfb7b5dbf0643f7c023ae1fba619",
-                "sha256:608e7073dfa9e38a85d38474c082d4281f4ce276ac0010224eaba11e929dd53a",
-                "sha256:63ba06c9941e46fa389d389644e2d8225e0e3e5ebcc4ff1ea8506dce646f8c8a",
-                "sha256:65608c35bfb8a76763f37036547f7adfd09270fbdbf96608be2bead319728fcd",
-                "sha256:665a36ae6f8f20a4676b53224e33d456a6f5a72657d9c83c2aa00765072f31f7",
-                "sha256:6d6607f98fcf17e534162f0709aaad3ab7a96032723d8ac8750ffe17ae5a0666",
-                "sha256:7313ce6a199651c4ed9d7e4cfb4aa56fe923b1adf9af3b420ee14e6d9a73df65",
-                "sha256:7668b52e102d0ed87cb082380a7e2e1e78737ddecdde129acadb0eccc5423859",
-                "sha256:7df70907e00c970c60b9ef2938d894a9381f38e6b9db73c5be35e59d92e06625",
-                "sha256:7e007132af78ea9df29495dbf7b5824cb71648d7133cf7848a2a5dd00d36f9ff",
-                "sha256:835fb5e38fd89328e9c81067fd642b3593c33e1e17e2fdbf77f5676abb14a156",
-                "sha256:8bca7e26c1dd751236cfb0c6c72d4ad61d986e9a41bbf76cb445f69488b2a2bd",
-                "sha256:8db032bf0ce9022a8e41a22598eefc802314e81b879ae093f36ce9ddf39ab1ba",
-                "sha256:99625a92da8229df6d44335e6fcc558a5037dd0a760e11d84be2260e6f37002f",
-                "sha256:9cad97ab29dfc3f0249b483412c85c8ef4766d96cdf9dcf5a1e3caa3f3661cf1",
-                "sha256:a4abaec6ca3ad8660690236d11bfe28dfd707778e2442b45addd2f086d6ef094",
-                "sha256:a6e40afa7f45939ca356f348c8e23048e02cb109ced1eb8420961b2f40fb373a",
-                "sha256:a6f2fcca746e8d5910e18782f976489939d54a91f9411c32051b4aab2bd7c513",
-                "sha256:a806db027852538d2ad7555b203300173dd1b77ba116de92da9afbc3a3be3eed",
-                "sha256:abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d",
-                "sha256:b8526c6d437855442cdd3d87eede9c425c4445ea011ca38d937db299382e6fa3",
-                "sha256:bb06feb762bade6bf3c8b844462274db0c76acc95c52abe8dbed28ae3d44a147",
-                "sha256:c0a33bc9f02c2b17c3ea382f91b4db0e6cde90b63b296422a939886a7a80de1c",
-                "sha256:c4a549890a45f57f1ebf99c067a4ad0cb423a05544accaf2b065246827ed9603",
-                "sha256:ca244fa73f50a800cf8c3ebf7fd93149ec37f5cb9596aa8873ae2c1d23498601",
-                "sha256:cf877ab4ed6e302ec1d04952ca358b381a882fbd9d1b07cccbfd61783561f98a",
-                "sha256:d9d971ec1e79906046aa3ca266de79eac42f1dbf3612a05dc9368125952bd1a1",
-                "sha256:da25303d91526aac3672ee6d49a2f3db2d9502a4a60b55519feb1a4c7714e07d",
-                "sha256:e55e40ff0cc8cc5c07996915ad367fa47da6b3fc091fdadca7f5403239c5fec3",
-                "sha256:f03a532d7dee1bed20bc4884194a16160a2de9ffc6354b3878ec9682bb623c54",
-                "sha256:f1cd098434e83e656abf198f103a8207a8187c0fc110306691a2e94a78d0abb2",
-                "sha256:f2bfb563d0211ce16b63c7cb9395d2c682a23187f54c3d79bfec33e6705473c6",
-                "sha256:f8ffb705ffcf5ddd0e80b65ddf7bed7ee4f5a441ea7d3419e861a12eaf41af58"
+                "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+                "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+                "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
+                "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
+                "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
+                "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
+                "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
+                "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
+                "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
+                "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+                "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
+                "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
+                "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
+                "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
+                "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
+                "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
+                "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
+                "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
+                "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
+                "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+                "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
+                "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
+                "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
+                "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
+                "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
+                "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
+                "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
+                "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+                "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
+                "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
+                "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2",
+                "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
+                "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
+                "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
+                "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
+                "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
+                "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
+                "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
+                "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
+                "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
+                "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
+                "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.2"
+            "version": "==2.1.3"
+        },
+        "marshmallow": {
+            "hashes": [
+                "sha256:90032c0fd650ce94b6ec6dc8dfeb0e3ff50c144586462c389b81a07205bedb78",
+                "sha256:93f0958568da045b0021ec6aeb7ac37c81bfcccbb9a0e7ed8559885070b3a19b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.19.0"
+        },
+        "marshmallow-sqlalchemy": {
+            "hashes": [
+                "sha256:ba7493eeb8669a3bf00d8f906b657feaa87a740ae9e4ecf829cfd6ddf763d276",
+                "sha256:d8525f74de51554b5c8491effe036f60629a426229befa33ff614c8569a16a73"
+            ],
+            "index": "pypi",
+            "version": "==0.26.1"
         },
         "mysqlclient": {
             "hashes": [
@@ -336,6 +384,14 @@
             ],
             "index": "pypi",
             "version": "==2.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1"
         },
         "patreon": {
             "git": "https://github.com/Patreon/patreon-python.git",
@@ -407,71 +463,71 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:07950fc82f844a2de67ddb4e535f29b65652b4d95e8b847823ce66a6d540a41d",
-                "sha256:0a865b5ec4ba24f57c33b633b728e43fde77b968911a6046443f581b25d29dd9",
-                "sha256:0b49f1f71d7a44329a43d3edd38cc5ee4c058dfef4487498393d16172007954b",
-                "sha256:13f984a190d249769a050634b248aef8991acc035e849d02b634ea006c028fa8",
-                "sha256:1b69666e25cc03c602d9d3d460e1281810109e6546739187044fc256c67941ef",
-                "sha256:1d06e119cf79a3d80ab069f064a07152eb9ba541d084bdaee728d8a6f03fd03d",
-                "sha256:246712af9fc761d6c13f4f065470982e175d902e77aa4218c9cb9fc9ff565a0c",
-                "sha256:34eb96c1de91d8f31e988302243357bef3f7785e1b728c7d4b98bd0c117dafeb",
-                "sha256:4c3020afb144572c7bfcba9d7cce57ad42bff6e6115dffcfe2d4ae6d444a214f",
-                "sha256:4f759eccb66e6d495fb622eb7f4ac146ae674d829942ec18b7f5a35ddf029597",
-                "sha256:68ed381bc340b4a3d373dbfec1a8b971f6350139590c4ca3cb722fdb50035777",
-                "sha256:6b72dccc5864ea95c93e0a9c4e397708917fb450f96737b4a8395d009f90b868",
-                "sha256:6e84ab63d25d8564d7a8c05dc080659931a459ee27f6ed1cf4c91f292d184038",
-                "sha256:734805708632e3965c2c40081f9a59263c29ffa27cba9b02d4d92dfd57ba869f",
-                "sha256:78612edf4ba50d407d0eb3a64e9ec76e6efc2b5d9a5c63415d53e540266a230a",
-                "sha256:7e472e9627882f2d75b87ff91c5a2bc45b31a226efc7cc0a054a94fffef85862",
-                "sha256:865392a50a721445156809c1a6d6ab6437be70c1c2599f591a8849ed95d3c693",
-                "sha256:8d118e233f416d713aac715e2c1101e17f91e696ff315fc9efbc75b70d11e740",
-                "sha256:8d3ece5960b3e821e43a4927cc851b6e84a431976d3ffe02aadb96519044807e",
-                "sha256:93c78d42c14aa9a9e0866eacd5b48df40a50d0e2790ee377af7910d224afddcf",
-                "sha256:95719215e3ec7337b9f57c3c2eda0e6a7619be194a5166c07c1e599f6afc20fa",
-                "sha256:9838bd247ee42eb74193d865e48dd62eb50e45e3fdceb0fdef3351133ee53dcf",
-                "sha256:aa5c270ece17c0c0e0a38f2530c16b20ea05d8b794e46c79171a86b93b758891",
-                "sha256:ac6a0311fb21a99855953f84c43fcff4bdca27a2ffcc4f4d806b26b54b5cddc9",
-                "sha256:ad5363a1c65fde7b7466769d4261126d07d872fc2e816487ae6cec93da604b6b",
-                "sha256:b3e5864eba71a3718236a120547e52c8da2ccb57cc96cecd0480106a0c799c92",
-                "sha256:bbda1da8d541904ba262825a833c9f619e93cb3fd1156be0a5e43cd54d588dcd",
-                "sha256:c6e27189ff9aebfb2c02fd252c629ea58657e7a5ff1a321b7fc9c2bf6dc0b5f3",
-                "sha256:c8239ce63a90007bce479adf5460d48c1adae4b933d8e39a4eafecfc084e503c",
-                "sha256:d209594e68bec103ad5243ecac1b40bf5770c9ebf482df7abf175748a34f4853",
-                "sha256:d5327f54a9c39e7871fc532639616f3777304364a0bb9b89d6033ad34ef6c5f8",
-                "sha256:db4bd1c4792da753f914ff0b688086b9a8fd78bb9bc5ae8b6d2e65f176b81eb9",
-                "sha256:e4780be0f19e5894c17f75fc8de2fe1ae233ab37827125239ceb593c6f6bd1e2",
-                "sha256:e4a019f723b6c1e6b3781be00fb9e0844bc6156f9951c836ff60787cc3938d76",
-                "sha256:e62c4e762d6fd2901692a093f208a6a6575b930e9458ad58c2a7f080dd6132da",
-                "sha256:e730603cae5747bc6d6dece98b45a57d647ed553c8d5ecef602697b1c1501cf2",
-                "sha256:ebc4eeb1737a5a9bdb0c24f4c982319fa6edd23cdee27180978c29cbb026f2bd",
-                "sha256:ee2946042cc7851842d7a086a92b9b7b494cbe8c3e7e4627e27bc912d3a7655e",
-                "sha256:f005245e1cb9b8ca53df73ee85e029ac43155e062405015e49ec6187a2e3fb44",
-                "sha256:f49c5d3c070a72ecb96df703966c9678dda0d4cb2e2736f88d15f5e1203b4159",
-                "sha256:f61ab84956dc628c8dfe9d105b6aec38afb96adae3e5e7da6085b583ff6ea789"
+                "sha256:1a0754c2d9f0c7982bec0a31138e495ed1f6b8435d7e677c45be60ec18370acf",
+                "sha256:1d6320a1d175447dce63618ec997a53836de48ed3b44bbe952f0b4b399b19941",
+                "sha256:1e885dacb167077df15af2f9ccdacbd7f5dd0d538a6d74b94074f2cefc7bb589",
+                "sha256:201a99f922ac8c780b3929128fbd9df901418877c70e160e19adb05665e51c31",
+                "sha256:21c89044fc48a25c2184eba332edeffbbf9367913bb065cd31538235d828f06f",
+                "sha256:256b2b9660e51ad7055a9835b12717416cf7288afcf465107413917b6bb2316f",
+                "sha256:2e940a8659ef870ae10e0d9e2a6d5aaddf0ff6e91f7d0d7732afc9e8c4be9bbc",
+                "sha256:3fb5d09f1d51480f711b69fe28ad42e4f8b08600a85ab2473baee669e1257800",
+                "sha256:435f6807fa6a0597d84741470f19db204a7d34625ea121abd63e8d95f673f0c4",
+                "sha256:4670ce853cb25f72115a1bbe366ae13cf3f28fc5c87222df14f8d3d55d51816e",
+                "sha256:4a75fdb9a84072521bb2ebd31eefe1165d4dccea3039dda701a864f4b5daa17f",
+                "sha256:4d61731a35eddb0f667774fe15e5a4831e444d066081d1e809e1b8a0e3f97cae",
+                "sha256:51b19887c96d405599880da6a7cbdf8545a7e78ec5683e46a43bac8885e32d0f",
+                "sha256:536c86ec81ca89291d533ff41a3a05f9e4e88e01906dcee0751fc7082f3e8d6c",
+                "sha256:55ec62ddc0200b4fee94d11abbec7aa25948d5d21cb8df8807f4bdd3c51ba44b",
+                "sha256:5cc48a7fda2b5c5b8860494d6c575db3a101a68416492105fed6591dc8a2728a",
+                "sha256:670ecf74ee2e70b917028a06446ad26ff9b1195e84b09c3139c215123d57dc30",
+                "sha256:6a3f8020e013e9b3b7941dcf20b0fc8f7429daaf7158760846731cbd8caa5e45",
+                "sha256:6b42913a0259267e9ee335da0c36498077799e59c5e332d506e72b4f32de781d",
+                "sha256:6f5784dfb2d45c19cde03c45c04a54bf47428610106197ed6e6fa79f33bc63d3",
+                "sha256:6f80a9c9a9af0e4bd5080cc0955ce70274c28e9b931ad7e0fb07021afcd32af6",
+                "sha256:78303719c6f72af97814b0072ad18bee72e70adca8d95cf8fecd59c5e1ddb040",
+                "sha256:788d1772fb8dcd12091ca82809eef504ce0f2c423e45284bc351b872966ff554",
+                "sha256:79bfe728219239bdc493950ea4a4d15b02138ecb304771f9024d0d6f5f4e3706",
+                "sha256:810199d1c5b43603a9e815ae9487aef3ab1ade7ed9c0c485e12519358929fbfe",
+                "sha256:88ab245ed2c96265441ed2818977be28c840cfa5204ba167425d6c26eb67b7e7",
+                "sha256:933d30273861fe61f014ce2a7e3c364915f5efe9ed250ec1066ca6ea5942c0bd",
+                "sha256:994a75b197662e0608b6a76935d7c345f7fd874eac0b7093d561033db61b0e8c",
+                "sha256:9b31ebde27575b3b0708673ec14f0c305c4564d995b545148ab7ac0f4d9b847a",
+                "sha256:9d810b4aacd5ef4e293aa4ea01f19fca53999e9edcfc4a8ef1146238b30bdc28",
+                "sha256:ae1d8deb391ab39cc8f0d5844e588a115ae3717e607d91482023917f920f777f",
+                "sha256:bc5c2b0da46c26c5f73f700834f871d0723e1e882641932468d56833bab09775",
+                "sha256:cea7c4a3dfc2ca61f88a2b1ddd6b0bfbd116c9b1a361b3b66fd826034b833142",
+                "sha256:d14282bf5b4de87f922db3c70858953fd081ef4f05dba6cca3dd705daffe1cc9",
+                "sha256:d6b17cb86908e7f88be14007d6afe7d2ab11966e373044137f96a6a4d83eb21c",
+                "sha256:da7381a883aee20b7d2ffda17d909b38134b6a625920e65239a1c681881df800",
+                "sha256:db269f67ed17b07e80aaa8fba1f650c0d84aa0bdd9d5352e4ac38d5bf47ac568",
+                "sha256:df25052b92bd514357a9b370d74f240db890ea79aaa428fb893520e10ee5bc18",
+                "sha256:e17fdcb8971e77c439113642ca8861f9465e21fc693bd3916654ceef3ac26883",
+                "sha256:f6fd3c88ea4b170d13527e93be1945e69facd917661d3725a63470eb683fbffe",
+                "sha256:f7f994a53c0e6b44a2966fd6bfc53e37d34b7dca34e75b6be295de6db598255e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.9"
+            "version": "==2.0.15"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
-                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
+                "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26",
+                "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.5.0"
+            "version": "==4.6.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
-                "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"
+                "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f",
+                "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.15"
+            "version": "==1.26.16"
         },
         "uwsgi": {
             "hashes": [
@@ -479,6 +535,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.21"
+        },
+        "webargs": {
+            "hashes": [
+                "sha256:6746327faf549533bf30be7333f99541b6c60a85f23acf1bb0bea68498e3bcd7",
+                "sha256:99d68940c452e07726485a15fef43f12f8ae6c0c5b391bcba76065d4527fb85d"
+            ],
+            "markers": "python_full_version >= '3.7.2'",
+            "version": "==8.2.0"
         },
         "werkzeug": {
             "hashes": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,12 @@ pyyaml==5.4
 cachetools==4.0.0
 
 flask==1.1.1
+flask-apispec==0.11.0
 flask-cors==3.0.9
+flask-marshmallow==0.14.0
 flask-restful==0.3.9
 flask-sqlalchemy==2.5.1
+flask-swagger-ui==4.11.1
 
 elastic-apm[flask]==5.10.0
 

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -3,7 +3,10 @@ from os import environ
 from flask import Flask
 from flask_cors import CORS
 from flask_restful import Api
+from flask_apispec import FlaskApiSpec
+from flask_marshmallow import Marshmallow
 from flask_sqlalchemy import SQLAlchemy
+from flask_swagger_ui import get_swaggerui_blueprint
 
 from app import cfg
 
@@ -44,6 +47,8 @@ if environ.get("APM") == "True":
 
     apm = ElasticAPM(app)
 
+app.config['APISPEC_SWAGGER_URL'] = '/docs_json'
+
 app.url_map.strict_slashes = False
 
 cors = CORS(app, resources={r"*": {"origins": "*"}})
@@ -70,6 +75,17 @@ sqlalchemy_ext = SQLAlchemy(app)
 
 api = Api(app)
 
+ma_ext = Marshmallow(app)
+docs_ext = FlaskApiSpec(app)
+
+# Register the swagger docs blueprint
+app.register_blueprint(get_swaggerui_blueprint(
+    "/",
+    "/docs_json",
+    config={
+        "app_name": "BeeStation API"
+    }
+))
 
 @app.context_processor
 def context_processor():

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -12,6 +12,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_swagger_ui import get_swaggerui_blueprint
 
 from webargs.flaskparser import parser
+
 parser.location = "query"
 
 from app import cfg
@@ -54,14 +55,14 @@ if environ.get("APM") == "True":
     apm = ElasticAPM(app)
 
 
-app.config['APISPEC_SPEC'] = APISpec(
-    title='BeeStation API',
-    version='v2',
-    openapi_version='2.0',
+app.config["APISPEC_SPEC"] = APISpec(
+    title="BeeStation API",
+    version="v2",
+    openapi_version="2.0",
     plugins=[MarshmallowPlugin()],
 )
 
-app.config['APISPEC_SWAGGER_URL'] = '/docs_json'
+app.config["APISPEC_SWAGGER_URL"] = "/docs_json"
 
 app.url_map.strict_slashes = False
 
@@ -91,6 +92,7 @@ api = Api(app)
 
 ma_ext = Marshmallow(app)
 docs_ext = FlaskApiSpec(app)
+
 
 # This error handler is necessary for usage with Flask-RESTful
 @parser.error_handler
@@ -149,13 +151,8 @@ docs_ext.register(ServerStatsResource)
 docs_ext.register(StatsTotalsResource)
 
 # Register the swagger docs blueprint
-app.register_blueprint(get_swaggerui_blueprint(
-    "/docs",
-    "/docs_json",
-    config={
-        "app_name": "BeeStation API"
-    }
-))
+app.register_blueprint(get_swaggerui_blueprint("/docs", "/docs_json", config={"app_name": "BeeStation API"}))
+
 
 @app.route("/")
 def docs_redirect():

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -2,15 +2,13 @@ from os import environ
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
-
 from flask import Flask, abort, redirect
-from flask_cors import CORS
-from flask_restful import Api
 from flask_apispec import FlaskApiSpec
+from flask_cors import CORS
 from flask_marshmallow import Marshmallow
+from flask_restful import Api
 from flask_sqlalchemy import SQLAlchemy
 from flask_swagger_ui import get_swaggerui_blueprint
-
 from webargs.flaskparser import parser
 
 parser.location = "query"

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,12 +1,18 @@
 from os import environ
 
-from flask import Flask
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+
+from flask import Flask, abort, redirect
 from flask_cors import CORS
 from flask_restful import Api
 from flask_apispec import FlaskApiSpec
 from flask_marshmallow import Marshmallow
 from flask_sqlalchemy import SQLAlchemy
 from flask_swagger_ui import get_swaggerui_blueprint
+
+from webargs.flaskparser import parser
+parser.location = "query"
 
 from app import cfg
 
@@ -47,6 +53,14 @@ if environ.get("APM") == "True":
 
     apm = ElasticAPM(app)
 
+
+app.config['APISPEC_SPEC'] = APISpec(
+    title='BeeStation API',
+    version='v2',
+    openapi_version='2.0',
+    plugins=[MarshmallowPlugin()],
+)
+
 app.config['APISPEC_SWAGGER_URL'] = '/docs_json'
 
 app.url_map.strict_slashes = False
@@ -78,25 +92,16 @@ api = Api(app)
 ma_ext = Marshmallow(app)
 docs_ext = FlaskApiSpec(app)
 
-# Register the swagger docs blueprint
-app.register_blueprint(get_swaggerui_blueprint(
-    "/",
-    "/docs_json",
-    config={
-        "app_name": "BeeStation API"
-    }
-))
-
-@app.context_processor
-def context_processor():
-    from app import db, util
-
-    return dict(cfg=cfg, db=db, util=util)
+# This error handler is necessary for usage with Flask-RESTful
+@parser.error_handler
+def handle_request_parsing_error(err, req, schema, *, error_status_code, error_headers):
+    abort(400, err.messages)
 
 
 from app.resources.bans import BanListResource
 
 api.add_resource(BanListResource, "/bans")
+docs_ext.register(BanListResource)
 
 from app.resources.general import (
     PlayerListResource,
@@ -109,11 +114,17 @@ api.add_resource(VersionResource, "/version")
 api.add_resource(PlayerListResource, "/playerlist")
 api.add_resource(ServerPlayerListResource, "/playerlist/<string:id>")
 api.add_resource(ServerListResource, "/servers")
+docs_ext.register(VersionResource)
+docs_ext.register(PlayerListResource)
+docs_ext.register(ServerPlayerListResource)
+docs_ext.register(ServerListResource)
 
 from app.resources.library import BookListResource, BookResource
 
 api.add_resource(BookListResource, "/library")
 api.add_resource(BookResource, "/library/<int:bookid>")
+docs_ext.register(BookListResource)
+docs_ext.register(BookResource)
 
 from app.resources.patreon import (
     BudgetResource,
@@ -124,9 +135,28 @@ from app.resources.patreon import (
 api.add_resource(PatreonOuathResource, "/patreonauth")
 api.add_resource(LinkedPatreonListResource, "/linked_patreons")
 api.add_resource(BudgetResource, "/budget")
+docs_ext.register(PatreonOuathResource)
+docs_ext.register(LinkedPatreonListResource)
+docs_ext.register(BudgetResource)
 
 from app.resources.stats import ServerStatsResource, StatsResource, StatsTotalsResource
 
 api.add_resource(StatsResource, "/stats")
 api.add_resource(ServerStatsResource, "/stats/<string:id>")
 api.add_resource(StatsTotalsResource, "/stats/totals")
+docs_ext.register(StatsResource)
+docs_ext.register(ServerStatsResource)
+docs_ext.register(StatsTotalsResource)
+
+# Register the swagger docs blueprint
+app.register_blueprint(get_swaggerui_blueprint(
+    "/docs",
+    "/docs_json",
+    config={
+        "app_name": "BeeStation API"
+    }
+))
+
+@app.route("/")
+def docs_redirect():
+    return redirect("/docs")

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import sqlalchemy_ext, ma_ext
+from app import ma_ext, sqlalchemy_ext
 
 db_session = sqlalchemy_ext.session
 

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -191,6 +191,7 @@ class Book(sqlalchemy_ext.Model):
         except NoResultFound:
             return None
 
+
 class BookSchema(ma_ext.SQLAlchemyAutoSchema):
     class Meta:
         model = Book

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -191,18 +191,9 @@ class Book(sqlalchemy_ext.Model):
         except NoResultFound:
             return None
 
-    def to_public_dict(self):
-        return {
-            "id": self.id,
-            "author": self.author,
-            "title": self.title,
-            "content": self.content,
-            "category": self.category,
-            "ckey": self.ckey,
-            "datetime": self.datetime,
-            "deleted": self.deleted,
-            "round_id_created": self.round_id_created,
-        }
+class BookSchema(ma_ext.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Book
 
 
 class Ban(sqlalchemy_ext.Model):

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import sqlalchemy_ext
+from app import sqlalchemy_ext, ma_ext
 
 db_session = sqlalchemy_ext.session
 

--- a/src/app/resources/bans.py
+++ b/src/app/resources/bans.py
@@ -1,10 +1,9 @@
 import math
 
 from flask import jsonify, request
-from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
+from flask_apispec import MethodResource, doc, marshal_with, use_kwargs
 from flask_restful import Resource
-from marshmallow import schema, fields
-
+from marshmallow import fields, schema
 
 from app import cfg, db, ma_ext
 from app.schemas import *

--- a/src/app/resources/bans.py
+++ b/src/app/resources/bans.py
@@ -6,15 +6,15 @@ from flask_restful import Resource
 from marshmallow import schema, fields
 
 
-from app import cfg, db
+from app import cfg, db, ma_ext
 from app.schemas import *
 
-class BanListResource(Resource):
+class BanListResource(MethodResource):
     @doc(description="Get a paginated list of bans.")
     @use_kwargs(PaginationSearchQuerySchema)
     @marshal_with(PaginationResultSchema)
     def get(self, **kwargs):
-        page = max(min(kwargs.get("page", type=int, default=1), 1_000_000))
+        page = max(min(kwargs.get("page") or 1, 1_000_000), 1)
         query = db.query_grouped_bans(search_query=kwargs.get("search_query"))
         length = query.count()
 

--- a/src/app/resources/bans.py
+++ b/src/app/resources/bans.py
@@ -1,32 +1,29 @@
 import math
 
 from flask import jsonify, request
+from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
 from flask_restful import Resource
+from marshmallow import schema, fields
+
 
 from app import cfg, db
-
+from app.schemas import *
 
 class BanListResource(Resource):
-    def get(self):
-        page = request.args.get("page", type=int, default=1)
-        page = max(
-            min(page, 1_000_000), 1
-        )  # Arbitrary number. We probably won't ever have to deal with 1,000,000 pages of bans. Hopefully..
-
-        search_query = request.args.get("search_query", type=str, default="")
-
-        query = db.query_grouped_bans(search_query=search_query)
-
+    @doc(description="Get a paginated list of bans.")
+    @use_kwargs(PaginationSearchQuerySchema)
+    @marshal_with(PaginationResultSchema)
+    def get(self, **kwargs):
+        page = max(min(kwargs.get("page", type=int, default=1), 1_000_000))
+        query = db.query_grouped_bans(search_query=kwargs.get("search_query"))
         length = query.count()
 
         displayed_bans = query.offset((page - 1) * cfg.API["items-per-page"]).limit(cfg.API["items-per-page"])
 
-        return jsonify(
-            {
-                "page": page,
-                "pages": math.ceil(length / cfg.API["items-per-page"]),
-                "page_length": cfg.API["items-per-page"],
-                "total_length": length,
-                "data": [db.Ban.to_public_dict(ban) for ban in displayed_bans],
-            }
-        )
+        return {
+            "page": page,
+            "pages": math.ceil(length / cfg.API["items-per-page"]),
+            "page_length": cfg.API["items-per-page"],
+            "total_length": length,
+            "data": [db.Ban.to_public_dict(ban) for ban in displayed_bans]
+        }

--- a/src/app/resources/bans.py
+++ b/src/app/resources/bans.py
@@ -9,6 +9,7 @@ from marshmallow import schema, fields
 from app import cfg, db, ma_ext
 from app.schemas import *
 
+
 class BanListResource(MethodResource):
     @doc(description="Get a paginated list of bans.")
     @use_kwargs(PaginationSearchQuerySchema)
@@ -25,5 +26,5 @@ class BanListResource(MethodResource):
             "pages": math.ceil(length / cfg.API["items-per-page"]),
             "page_length": cfg.API["items-per-page"],
             "total_length": length,
-            "data": [db.Ban.to_public_dict(ban) for ban in displayed_bans]
+            "data": [db.Ban.to_public_dict(ban) for ban in displayed_bans],
         }

--- a/src/app/resources/general.py
+++ b/src/app/resources/general.py
@@ -1,15 +1,19 @@
 from flask import abort, jsonify
+from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
 from flask_restful import Resource
+from marshmallow import schema, fields
 
 from app import cfg, util
 
 
 class VersionResource(Resource):
+    @doc(description="Get the current version of the API.")
     def get(self):
         return cfg.VERSION
 
 
 class PlayerListResource(Resource):
+    @doc(description="Get a list of currently playing CKEYs on all servers.")
     def get(self):
         try:
             d = {}
@@ -28,6 +32,7 @@ class PlayerListResource(Resource):
 
 
 class ServerPlayerListResource(Resource):
+    @doc(description="Get a list of currently playing CKEYs on a specific server.")
     def get(self, id):
         if not util.get_server(id):
             return abort(404)
@@ -39,8 +44,6 @@ class ServerPlayerListResource(Resource):
 
 
 class ServerListResource(Resource):
+    @doc(description="Get a list of the manifest details of all servers.")
     def get(self):
-        try:
-            return jsonify(cfg.SERVERS)
-        except Exception as E:
-            return jsonify({"error": str(E)})
+        return jsonify(cfg.SERVERS)

--- a/src/app/resources/general.py
+++ b/src/app/resources/general.py
@@ -3,16 +3,16 @@ from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
 from flask_restful import Resource
 from marshmallow import schema, fields
 
-from app import cfg, util
+from app import cfg, util, ma_ext
 
 
-class VersionResource(Resource):
+class VersionResource(MethodResource):
     @doc(description="Get the current version of the API.")
     def get(self):
         return cfg.VERSION
 
 
-class PlayerListResource(Resource):
+class PlayerListResource(MethodResource):
     @doc(description="Get a list of currently playing CKEYs on all servers.")
     def get(self):
         try:
@@ -31,11 +31,11 @@ class PlayerListResource(Resource):
             return jsonify({"error": str(E)})
 
 
-class ServerPlayerListResource(Resource):
+class ServerPlayerListResource(MethodResource):
     @doc(description="Get a list of currently playing CKEYs on a specific server.")
     def get(self, id):
         if not util.get_server(id):
-            return abort(404)
+            return abort(404, {"error": "unknown server"})
 
         try:
             return jsonify(util.fetch_server_players(id))
@@ -43,7 +43,7 @@ class ServerPlayerListResource(Resource):
             return jsonify({"error": str(E)})
 
 
-class ServerListResource(Resource):
+class ServerListResource(MethodResource):
     @doc(description="Get a list of the manifest details of all servers.")
     def get(self):
         return jsonify(cfg.SERVERS)

--- a/src/app/resources/general.py
+++ b/src/app/resources/general.py
@@ -1,9 +1,9 @@
 from flask import abort, jsonify
-from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
+from flask_apispec import MethodResource, doc, marshal_with, use_kwargs
 from flask_restful import Resource
-from marshmallow import schema, fields
+from marshmallow import fields, schema
 
-from app import cfg, util, ma_ext
+from app import cfg, ma_ext, util
 
 
 class VersionResource(MethodResource):

--- a/src/app/resources/library.py
+++ b/src/app/resources/library.py
@@ -35,5 +35,6 @@ class BookResource(MethodResource):
     @marshal_with(db.BookSchema)
     def get(self, bookid):
         book = db.Book.from_id(bookid)
-        if not book: abort(404, {"error": "book not found"})
+        if not book:
+            abort(404, {"error": "book not found"})
         return book

--- a/src/app/resources/library.py
+++ b/src/app/resources/library.py
@@ -1,7 +1,7 @@
 import math
 
 from flask import abort, jsonify, request
-from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
+from flask_apispec import MethodResource, doc, marshal_with, use_kwargs
 from flask_restful import Resource
 from marshmallow import Schema, fields
 

--- a/src/app/resources/library.py
+++ b/src/app/resources/library.py
@@ -25,7 +25,7 @@ class BookListResource(MethodResource):
                 "pages": math.ceil(length / cfg.API["items-per-page"]),
                 "page_length": cfg.API["items-per-page"],
                 "total_length": length,
-                "data": [book.to_public_dict() for book in displayed_books],
+                "data": [db.BookSchema().dump(book) for book in displayed_books],
             }
         )
 

--- a/src/app/resources/patreon.py
+++ b/src/app/resources/patreon.py
@@ -2,12 +2,12 @@ import patreon
 from flask import jsonify, redirect, request
 from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
 from flask_restful import Resource
-from marshmallow import schema, fields
+from marshmallow import Schema, fields
 
-from app import cfg, db, util
+from app import cfg, db, util, ma_ext
+from app.schemas import *
 
-
-class PatreonOuathResource(Resource):
+class PatreonOuathResource(MethodResource):
     @doc(description="Patreon oauth callback.")
     def get(self):
         code = request.args.get("code")
@@ -42,7 +42,7 @@ class PatreonLinkSchema(Schema):
     ckey = fields.String()
     patreon_id = fields.String()
 
-class LinkedPatreonListResource(Resource):
+class LinkedPatreonListResource(MethodResource):
     @marshal_with(PatreonLinkSchema(many=True))
     @use_kwargs(APIPasswordRequiredSchema)
     @doc(description="Get a list of linked ckey-Patreon accounts.")
@@ -62,7 +62,7 @@ class BudgetSchema(Schema):
     goal = fields.Integer()
     percent = fields.Integer()
 
-class BudgetResource(Resource):
+class BudgetResource(MethodResource):
     @marshal_with(BudgetSchema)
     @doc(description="Get Patreon donation goal information.")
     def get(self):

--- a/src/app/resources/patreon.py
+++ b/src/app/resources/patreon.py
@@ -1,10 +1,10 @@
 import patreon
 from flask import jsonify, redirect, request
-from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
+from flask_apispec import MethodResource, doc, marshal_with, use_kwargs
 from flask_restful import Resource
 from marshmallow import Schema, fields
 
-from app import cfg, db, util, ma_ext
+from app import cfg, db, ma_ext, util
 from app.schemas import *
 
 

--- a/src/app/resources/patreon.py
+++ b/src/app/resources/patreon.py
@@ -7,6 +7,7 @@ from marshmallow import Schema, fields
 from app import cfg, db, util, ma_ext
 from app.schemas import *
 
+
 class PatreonOuathResource(MethodResource):
     @doc(description="Patreon oauth callback.")
     def get(self):
@@ -42,6 +43,7 @@ class PatreonLinkSchema(Schema):
     ckey = fields.String()
     patreon_id = fields.String()
 
+
 class LinkedPatreonListResource(MethodResource):
     @marshal_with(PatreonLinkSchema(many=True))
     @use_kwargs(APIPasswordRequiredSchema)
@@ -61,6 +63,7 @@ class BudgetSchema(Schema):
     income = fields.Integer()
     goal = fields.Integer()
     percent = fields.Integer()
+
 
 class BudgetResource(MethodResource):
     @marshal_with(BudgetSchema)

--- a/src/app/resources/stats.py
+++ b/src/app/resources/stats.py
@@ -1,11 +1,12 @@
 from flask import abort, jsonify
 from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
 from flask_restful import Resource
-from marshmallow import schema, fields
+from marshmallow import Schema, fields
 
-from app import cfg, util
+from app import cfg, util, ma_ext
+from app.schemas import *
 
-class StatsResource(Resource):
+class StatsResource(MethodResource):
     @doc(description="Returns the JSON data from the ?status game query of all servers.")
     def get(self):
         try:
@@ -24,7 +25,7 @@ class StatsResource(Resource):
             abort(500, {"error": str(E)})
 
 
-class ServerStatsResource(Resource):
+class ServerStatsResource(MethodResource):
     @doc(description="Returns the JSON data from the ?status game query of the specified server.")
     def get(self, id):
         if not util.get_server(id):
@@ -41,7 +42,7 @@ class StatsTotalsSchema(Schema):
     total_rounds = fields.Integer()
     total_connections = fields.Integer()
 
-class StatsTotalsResource(Resource):
+class StatsTotalsResource(MethodResource):
     @doc(description="Returns total unique players, total rounds, and total connections.")
     @marshal_with(StatsTotalsSchema)
     def get(self):

--- a/src/app/resources/stats.py
+++ b/src/app/resources/stats.py
@@ -1,10 +1,12 @@
 from flask import abort, jsonify
+from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
 from flask_restful import Resource
+from marshmallow import schema, fields
 
 from app import cfg, util
 
-
 class StatsResource(Resource):
+    @doc(description="Returns the JSON data from the ?status game query of all servers.")
     def get(self):
         try:
             d = {}
@@ -19,23 +21,28 @@ class StatsResource(Resource):
             return jsonify(d)
 
         except Exception as E:
-            return jsonify({"error": str(E)})
+            abort(500, {"error": str(E)})
 
 
 class ServerStatsResource(Resource):
+    @doc(description="Returns the JSON data from the ?status game query of the specified server.")
     def get(self, id):
         if not util.get_server(id):
-            return abort(404)
+            return abort(404, {"error": "unknown server"})
 
         try:
             return jsonify(util.fetch_server_status(id))
         except Exception as E:
-            return jsonify({"error": str(E)})
+            abort(500, {"error": str(E)})
 
+
+class StatsTotalsSchema(Schema):
+    total_players = fields.Integer()
+    total_rounds = fields.Integer()
+    total_connections = fields.Integer()
 
 class StatsTotalsResource(Resource):
+    @doc(description="Returns total unique players, total rounds, and total connections.")
+    @marshal_with(StatsTotalsSchema)
     def get(self):
-        try:
-            return jsonify(util.fetch_server_totals())
-        except Exception as E:
-            return jsonify({"error": str(E)})
+        return util.fetch_server_totals()

--- a/src/app/resources/stats.py
+++ b/src/app/resources/stats.py
@@ -6,6 +6,7 @@ from marshmallow import Schema, fields
 from app import cfg, util, ma_ext
 from app.schemas import *
 
+
 class StatsResource(MethodResource):
     @doc(description="Returns the JSON data from the ?status game query of all servers.")
     def get(self):
@@ -41,6 +42,7 @@ class StatsTotalsSchema(Schema):
     total_players = fields.Integer()
     total_rounds = fields.Integer()
     total_connections = fields.Integer()
+
 
 class StatsTotalsResource(MethodResource):
     @doc(description="Returns total unique players, total rounds, and total connections.")

--- a/src/app/resources/stats.py
+++ b/src/app/resources/stats.py
@@ -1,9 +1,9 @@
 from flask import abort, jsonify
-from flask_apispec import MethodResource, use_kwargs, marshal_with, doc
+from flask_apispec import MethodResource, doc, marshal_with, use_kwargs
 from flask_restful import Resource
 from marshmallow import Schema, fields
 
-from app import cfg, util, ma_ext
+from app import cfg, ma_ext, util
 from app.schemas import *
 
 

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -1,0 +1,18 @@
+from marshmallow import Schema, fields
+
+class PaginationSearchQuerySchema(Schema):
+    page = fields.Integer(required=False)
+    search_query = fields.String(required=False)
+
+class PaginationQuerySchema(Schema):
+    page = fields.Integer(required=False)
+
+class PaginationResultSchema(Schema):
+    page = fields.Integer()
+    pages = fields.Integer()
+    pange_length = fields.Integer()
+    total_length = fields.Integer()
+    data = fields.List(fields.Dict())
+
+class APIPasswordRequiredSchema(Schema):
+    api_pass = fields.String(required=True, data_key="pass")

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -1,11 +1,14 @@
 from marshmallow import Schema, fields
 
+
 class PaginationSearchQuerySchema(Schema):
     page = fields.Integer(required=False)
     search_query = fields.String(required=False)
 
+
 class PaginationQuerySchema(Schema):
     page = fields.Integer(required=False)
+
 
 class PaginationResultSchema(Schema):
     page = fields.Integer()
@@ -13,6 +16,7 @@ class PaginationResultSchema(Schema):
     pange_length = fields.Integer()
     total_length = fields.Integer()
     data = fields.List(fields.Dict())
+
 
 class APIPasswordRequiredSchema(Schema):
     api_pass = fields.String(required=True, data_key="pass")


### PR DESCRIPTION
documents apI endpoints, as promised to @Crossedfall 

i was not able to test any of the patreon related endpoints due to lack of Current patreon keys so i Apologize if any of those do not woRk, but i think thEy should

![image](https://github.com/BeeStation/bapi/assets/24400628/dadc02b9-7eb4-452f-9a52-8e64ce413464)

i also standardized semantics errors using marshmallow for query and response schemas:

![image](https://github.com/BeeStation/bapi/assets/24400628/a6e6b25b-f381-4864-bd21-97a95a551918)

the docs are accessible at `/docs`, which is redirected to from `/`