### PR TITLE
Suppresses timeout runtime errors for status checks

### DIFF
--- a/src/bapi/resources/stats.py
+++ b/src/bapi/resources/stats.py
@@ -24,6 +24,8 @@ class StatsResource(MethodResource):
 
             return jsonify(d)
 
+        except TimeoutError:
+            return jsonify({"error": "timed out"})
         except Exception as E:
             abort(500, {"error": str(E)})
 
@@ -36,6 +38,8 @@ class ServerStatsResource(MethodResource):
 
         try:
             return jsonify(util.fetch_server_status(id))
+        except TimeoutError:
+            return jsonify({"error": "timed out"})
         except Exception as E:
             abort(500, {"error": str(E)})
 


### PR DESCRIPTION
Removes a lot of log spam for an expected status